### PR TITLE
Fix fluent syntax issues

### DIFF
--- a/custom_components/react/config/fluent.py
+++ b/custom_components/react/config/fluent.py
@@ -46,13 +46,13 @@ FLUENT_BLOCK_OPTION_FORWARD_ACTION = "forward_action"
 FLUENT_BLOCK_OPTION_FORWARD_DATA = "forward_data"
 FLUENT_BLOCK_OPTION_RESTART_MODE_MODES = "abort|force|rerun"
 FLUENT_BLOCK_WAIT_DELAY_UNIT = "seconds|minutes|hours"
-FLUENT_BLOCK_WORD_NO_DOT = "[\w\d\-\+\:\/]+"
-FLUENT_BLOCK_WORD = "[\w\d\-\+\:\/\.\!]+"
-FLUENT_BLOCK_NUMBER = "[\d]+"
-FLUENT_BLOCK_TIME = "[\d\:]+"
-FLUENT_BLOCK_LIST_END = "(?!,\w)"
+FLUENT_BLOCK_WORD_NO_DOT = r"[\w\d\-\+\:\/]+"
+FLUENT_BLOCK_WORD = r"[\w\d\-\+\:\/\.\!]+"
+FLUENT_BLOCK_NUMBER = r"[\d]+"
+FLUENT_BLOCK_TIME = r"[\d\:]+"
+FLUENT_BLOCK_LIST_END = r"(?!,\w)"
 FLUENT_BLOCK_DATA = r'[^,]+?\=(?:{{.+?}}|".+?"|[^,]+)'
-FLUENT_BLOCK_WILDCARD = "\*"
+FLUENT_BLOCK_WILDCARD = r"\*"
 
 FLUENT_PARSE_DATA = r'(?P<key>[^,]+?)\=(?P<value>{{.+?}}|".+?"|[^,]+)'
 
@@ -96,7 +96,7 @@ def zero_or_many(value: str) -> str:
 
 
 def prepend_comma(value: str) -> str:
-    return f",\s*{value}"
+    return rf",\s*{value}"
 
 
 def tokenize(token: str, value: str):
@@ -108,7 +108,7 @@ def spaced(*args):
 
 
 def dotted(*args):
-    return '\.'.join(args)
+    return r'\.'.join(args)
 
 
 def piped(*args):

--- a/custom_components/react/config/fluent.py
+++ b/custom_components/react/config/fluent.py
@@ -51,8 +51,10 @@ FLUENT_BLOCK_WORD = "[\w\d\-\+\:\/\.\!]+"
 FLUENT_BLOCK_NUMBER = "[\d]+"
 FLUENT_BLOCK_TIME = "[\d\:]+"
 FLUENT_BLOCK_LIST_END = "(?!,\w)"
-FLUENT_BLOCK_DATA = "[^,]+\=[^,]+"
+FLUENT_BLOCK_DATA = r'[^,]+?\=(?:{{.+?}}|".+?"|[^,]+)'
 FLUENT_BLOCK_WILDCARD = "\*"
+
+FLUENT_PARSE_DATA = r'(?P<key>[^,]+?)\=(?P<value>{{.+?}}|".+?"|[^,]+)'
 
 FLUENT_TOKEN_RESET = "reset"
 FLUENT_TOKEN_USE = "use"
@@ -402,10 +404,8 @@ def parse_wait(match: re.Match):
 
 def parse_data(data: str):
     result = {}
-    data_items = data.split(',')
-    for data_item in data_items:
-        data_parts = data_item.split('=', 1) 
-        result[data_parts[0].strip()] = parse_numeric(data_parts[1].strip())
+    for match in re.finditer(FLUENT_PARSE_DATA, data):
+        result[match.group('key').strip()] = parse_numeric(match.group('value').strip().strip('"'))
     return result
 
 

--- a/package_constraints.txt
+++ b/package_constraints.txt
@@ -4,10 +4,10 @@ aiodhcpwatcher==1.0.0
 aiodiscover==2.1.0
 aiodns==3.2.0
 aiohttp-fast-url-dispatcher==0.3.0
-aiohttp-isal==0.2.0
+aiohttp-fast-zlib==0.1.0
 aiohttp==3.9.5
 aiohttp_cors==0.7.0
-aiohttp_session==2.12.0
+aiozoneinfo==0.1.0
 astral==2.2
 async-interrupt==1.1.1
 async-upnp-client==0.38.3
@@ -16,30 +16,30 @@ attrs==23.2.0
 awesomeversion==24.2.0
 bcrypt==4.1.2
 bleak-retry-connector==3.5.0
-bleak==0.21.1
-bluetooth-adapters==0.19.1
+bleak==0.22.1
+bluetooth-adapters==0.19.2
 bluetooth-auto-recovery==1.4.2
 bluetooth-data-tools==1.19.0
 cached_ipaddress==0.3.0
 certifi>=2021.5.30
 ciso8601==2.3.1
 cryptography==42.0.5
-dbus-fast==2.21.1
+dbus-fast==2.21.3
 fnv-hash-fast==0.5.0
 ha-av==10.1.1
 ha-ffmpeg==3.2.0
-habluetooth==2.8.0
-hass-nabucasa==0.78.0
-hassil==1.6.1
+habluetooth==3.1.1
+hass-nabucasa==0.81.1
+hassil==1.7.1
 home-assistant-bluetooth==1.12.0
-home-assistant-frontend==20240501.0
-home-assistant-intents==2024.4.24
+home-assistant-frontend==20240605.0
+home-assistant-intents==2024.6.5
 httpx==0.27.0
 ifaddr==0.2.0
-Jinja2==3.1.3
+Jinja2==3.1.4
 lru-dict==1.3.0
 mutagen==1.47.0
-orjson==3.9.15
+orjson==3.10.3
 packaging>=23.1
 paho-mqtt==1.6.1
 Pillow==10.3.0
@@ -54,8 +54,8 @@ PyTurboJPEG==1.7.1
 pyudev==0.24.1
 PyYAML==6.0.1
 requests==2.31.0
-SQLAlchemy==2.0.29
-typing-extensions>=4.11.0,<5.0
+SQLAlchemy==2.0.30
+typing-extensions>=4.12.0,<5.0
 ulid-transform==0.9.0
 urllib3>=1.26.5,<2
 voluptuous-serialize==2.6.0
@@ -133,7 +133,7 @@ backoff>=2.0
 
 # Required to avoid breaking (#101042).
 # v2 has breaking changes (#99218).
-pydantic==1.10.12
+pydantic==1.10.15
 
 # Breaks asyncio
 # https://github.com/pubnub/python/issues/130
@@ -192,3 +192,8 @@ pycountry>=23.12.11
 
 # scapy<2.5.0 will not work with python3.12
 scapy>=2.5.0
+
+# tuf isn't updated to deal with breaking changes in securesystemslib==1.0.
+# Only tuf>=4 includes a constraint to <1.0.
+# https://github.com/theupdateframework/python-tuf/releases/tag/v4.0.0
+tuf>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -c package_constraints.txt
 
 aiohttp_cors
-homeassistant==2024.5.0
+homeassistant==2024.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,14 +3,14 @@
 debugpy==1.8.1
 
 coverage==7.5.0
-pytest==8.1.1
+pytest==8.2.0
 pytest-asyncio==0.23.6
 pytest-cov==5.0.0
-pytest-homeassistant-custom-component==0.13.120
-pytest-xdist==3.5.0
+pytest-homeassistant-custom-component==0.13.132
+pytest-xdist==3.6.1
 
 # for homeassistant cloud, also used by mobile app
-hass-nabucasa==0.78.0
+hass-nabucasa==0.81.1
 hassil
 home-assistant-intents
 webrtcvad
@@ -19,10 +19,10 @@ mutagen
 deepdiff==6.3.0
 
 # for sonos
-soco==0.30.3
+soco==0.30.4
 async-upnp-client==0.38.3
 spotipy==2.23.0
-plexapi==4.15.12
+plexapi==4.15.13
 plexwebsocket==0.0.14
 
 # sonos_websocket
@@ -35,12 +35,12 @@ PyNaCl
 python-telegram-bot[socks]==21.0.1
 
 # for time
-freezegun==1.4.0
+freezegun==1.5.0
 
 Pillow
 
 # for unifi
-aiounifi==76
+aiounifi==77
 
 # for tts
 ha-ffmpeg==3.2.0

--- a/tests/_config/react.yaml
+++ b/tests/_config/react.yaml
@@ -181,7 +181,7 @@ workflow:
     variables:
       type_templated: "{{ 1 + 2 }}"
     when: actor_type_data.actor_entity_data actor_action_data with actor_data_data={{ type_templated }}
-    then: reactor_type_data.reactor_entity_data reactor_action_data with data1=1, data2={{ event.action }}, data3={{ type_templated }}, data5={{ actor.id }}, data6==
+    then: reactor_type_data.reactor_entity_data reactor_action_data with data1=1, data2={{ event.action }}, data3={{ type_templated }}, data5={{ actor.id }}, data6==, data7={{ 'as,df' }}, data8="qw,er", data9={{ 'true' if 1 == 1 else 'false' }}
 
   workflow_data_delayed:
     when: actor_type_data_delayed.actor_entity_data_delayed actor_action_data_delayed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,10 +61,10 @@ def verify_cleanup() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def hass_setup(hass: HomeAssistant, hass_api_mock):
+async def hass_setup(hass: HomeAssistant, hass_api_mock):
     hass.data[DATA_TRACE] = {}
     hass.data[HASS_API_MOCK] = HassApiMock(hass)
-    hass.config.set_time_zone("Europe/Amsterdam")
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
     hass.config.units = METRIC_SYSTEM
     result = Mock()
     result.hass = hass

--- a/tests/integration/test_events_with_data.py
+++ b/tests/integration/test_events_with_data.py
@@ -59,7 +59,10 @@ async def test_data_event(test_context: TstContext, workflow_name: str):
         "data3": 3,
         # "data4": ["asdf", "qwer"],
         "data5": int(test_context.workflow_config.actors[0].id),
-        "data6": '='
+        "data6": '=',
+        "data7": 'as,df',
+        "data8": 'qw,er',
+        "data9": 'true'
     }
     async with test_context.async_listen_reaction_event():
         test_context.verify_reaction_not_found()

--- a/tests/plugins/test_group_plugin.py
+++ b/tests/plugins/test_group_plugin.py
@@ -188,7 +188,7 @@ async def test_person_group_plugin_input_block_state_change(test_context: TstCon
         test_context.verify_action_event_data(
             expected_entity=entity_id,
             expected_type=GROUP_DOMAIN,
-            expected_action=f"{STATE_HOME}",
+            expected_action=f"{STATE_ON}",
             event_index=1)
         test_context.verify_action_event_data(
             expected_entity=entity_id,

--- a/tests/plugins/test_hass_plugin.py
+++ b/tests/plugins/test_hass_plugin.py
@@ -38,7 +38,7 @@ def get_mock_plugin(
     return result
 
 
-@pytest.mark.enable_socket
+# @pytest.mark.enable_socket
 @pytest.mark.parametrize(FIXTURE_WORKFLOW_NAME, ["hass_event_start_test"])
 async def test_hass_plugin_hass_start_action(test_context: TstContext, workflow_name: str):
     mock_plugin = get_mock_plugin()
@@ -59,7 +59,7 @@ async def test_hass_plugin_hass_start_action(test_context: TstContext, workflow_
         test_context.verify_has_no_log_issues()
 
 
-@pytest.mark.enable_socket
+# @pytest.mark.enable_socket
 @pytest.mark.parametrize(FIXTURE_WORKFLOW_NAME, ["hass_event_started_test"])
 async def test_hass_plugin_hass_started_action(test_context: TstContext, workflow_name: str):
     mock_plugin = get_mock_plugin()
@@ -80,7 +80,7 @@ async def test_hass_plugin_hass_started_action(test_context: TstContext, workflo
         test_context.verify_has_no_log_issues()
 
 
-@pytest.mark.enable_socket
+# @pytest.mark.enable_socket
 @pytest.mark.parametrize(FIXTURE_WORKFLOW_NAME, ["hass_event_shutdown_test"])
 async def test_hass_plugin_hass_shutdown_action(test_context: TstContext, workflow_name: str):
     mock_plugin = get_mock_plugin()


### PR DESCRIPTION
Fix issues in fluent syntax where comma's in jinja statements or strings were not interpreted as such but as data-item separators